### PR TITLE
run with docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,7 +10,4 @@ COPY src ./src
 
 RUN ./mvnw clean package -DskipTests
 
-RUN ls -lah /app
-RUN ls -lah /app/target
-
 CMD ["java", "-jar", "./target/coworkings-0.0.1-SNAPSHOT.jar"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,16 @@
+FROM openjdk:17-jdk-slim
+
+RUN apt-get update && apt-get install -y maven
+
+WORKDIR /app
+
+COPY pom.xml mvnw mvnw.cmd ./
+COPY .mvn .mvn
+COPY src ./src
+
+RUN ./mvnw clean package -DskipTests
+
+RUN ls -lah /app
+RUN ls -lah /app/target
+
+CMD ["java", "-jar", "./target/coworkings-0.0.1-SNAPSHOT.jar"]

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -1,0 +1,30 @@
+version: '3.8'
+# docker compose -f docker/compose.yml -p coworkings up -d --build --remove-orphans
+services:
+  backend:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+    ports:
+      - "8080:4200"
+    environment:
+      - SPRING_DATASOURCE_URL=jdbc:postgresql://db:5432/postgres
+      - SPRING_DATASOURCE_USERNAME=user
+      - SPRING_DATASOURCE_PASSWORD=password
+      - SOME_OTHER_VARIABLE=example_value
+    depends_on:
+      - db
+
+  db:
+    image: postgres:16-alpine
+    environment:
+      - POSTGRES_USER=user
+      - POSTGRES_PASSWORD=password
+      - POSTGRES_DB=postgres
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+
+volumes:
+  postgres_data:


### PR DESCRIPTION
Добавлена возможность запуска в докер-контейнере.
Поднимается стек из двух контейнеров:
1. db - postgres:16-alpine
2. backend - само приложение

Команда для запуска (из корня проекта):
```
docker compose -f docker/compose.yml -p coworkings up -d --build --remove-orphans
```

В `compose.yml` были изменены параметры БД (название, пользователь и пароль), чтобы использовалась база данных по умолчанию и не нужно было создавать вручную БД coworkings или писать дополнительные команды для автоматического создания.